### PR TITLE
fixes an exception when searching contacts

### DIFF
--- a/modules/linagora.esn.contact/backend/lib/search/index.js
+++ b/modules/linagora.esn.contact/backend/lib/search/index.js
@@ -40,7 +40,7 @@ module.exports = function(dependencies) {
   function searchContacts(query, callback) {
     logger.debug('Searching contacts with options', query);
     var terms = query.search;
-    var page = (query.page == NaN) ? (query.page || 1) : 1;
+    var page = query.page ? (query.page == NaN ? query.page : 1) : 1;
     var offset = query.offset;
     var limit = query.limit || DEFAULT_LIMIT;
 

--- a/modules/linagora.esn.contact/backend/lib/search/index.js
+++ b/modules/linagora.esn.contact/backend/lib/search/index.js
@@ -40,7 +40,7 @@ module.exports = function(dependencies) {
   function searchContacts(query, callback) {
     logger.debug('Searching contacts with options', query);
     var terms = query.search;
-    var page = query.page ? (query.page != NaN ? query.page : 1) : 1;
+    var page = query.page ? (!isNaN(query.page) ? query.page : 1) : 1;
     var offset = query.offset;
     var limit = query.limit || DEFAULT_LIMIT;
 

--- a/modules/linagora.esn.contact/backend/lib/search/index.js
+++ b/modules/linagora.esn.contact/backend/lib/search/index.js
@@ -40,7 +40,7 @@ module.exports = function(dependencies) {
   function searchContacts(query, callback) {
     logger.debug('Searching contacts with options', query);
     var terms = query.search;
-    var page = query.page || 1;
+    var page = (query.page == NaN) ? (query.page || 1) : 1;
     var offset = query.offset;
     var limit = query.limit || DEFAULT_LIMIT;
 

--- a/modules/linagora.esn.contact/backend/lib/search/index.js
+++ b/modules/linagora.esn.contact/backend/lib/search/index.js
@@ -40,7 +40,7 @@ module.exports = function(dependencies) {
   function searchContacts(query, callback) {
     logger.debug('Searching contacts with options', query);
     var terms = query.search;
-    var page = query.page ? (query.page == NaN ? query.page : 1) : 1;
+    var page = query.page ? (query.page != NaN ? query.page : 1) : 1;
     var offset = query.offset;
     var limit = query.limit || DEFAULT_LIMIT;
 


### PR DESCRIPTION
The exception occurs because the offset for the pagination was being calculated with a NaN, resulting in a NaN result. The previous implementation checked whether the page was defined, but didn't consider if it was not a number