### PR TITLE
Allow multiple users from the same organisation

### DIFF
--- a/frontend/views/modules/invitation/finalize.jade
+++ b/frontend/views/modules/invitation/finalize.jade
@@ -24,7 +24,6 @@
             required
             autocomplete='off'
             ng-minlength='1'
-            ensure-unique-company
             esn-track-first-blur
             ng-disabled='{{!editCompany}}'
             )


### PR DESCRIPTION
Currently, this form doesn't allow two users to sign-up with the same organisation name, it appears to be a design decision, but it seems like the most probable use-case of the openPaas is precisely among users of the same organisation.

This change allows them to do so.

The associated directive `ensureUniqueCompany` in the file `frontend/js/modules/company.js` may be useful for other usages, so it's kept